### PR TITLE
デフォルトのイメージをUbuntu14にする

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	imageName    = "S30GB_CENTOS7_64"
+	imageName    = "S30GB_UBUNTU14_64"
 	storageGroup = ""
 	serverGroup  = ""
 	serverType   = "VB0-1"


### PR DESCRIPTION
`--p2pub-system-storage` の値で、デフォルトはdriver.goのimageNameに書いてある。

S30GB_CENTOS7_64 → S30GB_UBUNTU14_64
