### PR TITLE
Add custom features for Rancher

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ Options
 | `--p2pub-ibb` | `IBBSERVICECODE` | | Data Storage Service Code |
 | `--p2pub-ivm` | `IVMSERVICECODE` | | Virtual Machine Service Code. add new if not specified |
 | `--p2pub-private-only` | | | don't attach global IP and set up DNS/Gateway for private network |
+| `--p2pub-custom-image` | | | Create boot device from storage archive. specify in the form of `iar service code`,`image id` |
+| `--p2pub-extra-ports` | | | Open some extra ports. specify in the form of `portnum`/`protocol(tcp,udp)` |
+| `--p2pub-reply-any-arp` | | | Set kernel parameters to reply any ARP requests. |
 
 ### create Swarm cluster
 

--- a/apicall.go
+++ b/apicall.go
@@ -268,6 +268,19 @@ func (d *Driver) removevm() error {
 	return nil
 }
 
+func (d *Driver) restore(iarServiceCode string, imageId string) error {
+	log.Info("Restore system storage.")
+	arg := protocol.Restore{
+		GisServiceCode: d.GisServiceCode,
+		IbaServiceCode: d.IbaServiceCode,
+		ImageId: imageId,
+		IarServiceCode: iarServiceCode,
+		Image: "Archive",
+	}
+	var res = protocol.RestoreResponse{}
+	return d.callapi(arg, &res)
+}
+
 func (d *Driver) setVMlabel(l string) error {
 	log.Info("setting vm label", l)
 	arg := protocol.VMLabelSet{

--- a/apicall.go
+++ b/apicall.go
@@ -270,15 +270,35 @@ func (d *Driver) removevm() error {
 
 func (d *Driver) restore(iarServiceCode string, imageId string) error {
 	log.Info("Restore system storage.")
-	arg := protocol.Restore{
+
+	get_arg := protocol.CustomOSImageGet{
+		GisServiceCode: d.GisServiceCode,
+		IarServiceCode: iarServiceCode,
+		ImageId: imageId,
+	}
+	var get_res = protocol.CustomOSImageGetResponse{}
+	if err := d.callapi(get_arg, &get_res); err != nil {
+		return err
+	}
+
+	d.ImageName = get_res.Type
+
+	if err := d.createdisk(); err != nil {
+		return err
+	}
+	if err := d.waitstatus("systemstorage", d.IbaServiceCode, "InService", "NotAttached"); err != nil {
+		return err
+	}
+	
+	restore_arg := protocol.Restore{
 		GisServiceCode: d.GisServiceCode,
 		IbaServiceCode: d.IbaServiceCode,
 		ImageId: imageId,
 		IarServiceCode: iarServiceCode,
 		Image: "Archive",
 	}
-	var res = protocol.RestoreResponse{}
-	return d.callapi(arg, &res)
+	var restore_res = protocol.RestoreResponse{}
+	return d.callapi(restore_arg, &restore_res)
 }
 
 func (d *Driver) setVMlabel(l string) error {

--- a/driver.go
+++ b/driver.go
@@ -112,18 +112,6 @@ func (d *Driver) Create() (err error) {
 		if err = d.setSysStlabel(d.MachineName); err != nil {
 			log.Warn("set label of SystemStorage failed:", err)
 		}
-		if err = ssh.GenerateSSHKey(d.GetSSHKeyPath()); err != nil {
-			log.Error(err)
-			return
-		}
-		var publicKey []byte
-		publicKey, err = ioutil.ReadFile(d.GetSSHKeyPath() + ".pub")
-		if err = d.setpubkey(string(publicKey)); err != nil {
-			return
-		}
-		if err = d.waitstatus("systemstorage", d.IbaServiceCode, "InService", "NotAttached"); err != nil {
-			return
-		}
 	}
 	if d.baseImage != "" {
 		restoreParams := strings.Split(d.baseImage, ",")
@@ -133,6 +121,18 @@ func (d *Driver) Create() (err error) {
  		if err = d.waitstatus("systemstorage", d.IbaServiceCode, "InService", "NotAttached"); err != nil {
  			return
  		}
+	}
+	if err = ssh.GenerateSSHKey(d.GetSSHKeyPath()); err != nil {
+		log.Error(err)
+		return
+	}
+	var publicKey []byte
+	publicKey, err = ioutil.ReadFile(d.GetSSHKeyPath() + ".pub")
+	if err = d.setpubkey(string(publicKey)); err != nil {
+		return
+	}
+	if err = d.waitstatus("systemstorage", d.IbaServiceCode, "InService", "NotAttached"); err != nil {
+		return
 	}
 	if d.IbbServiceCode == "" && d.addStorageType != "" {
 		if err = d.createdatadisk(); err != nil {

--- a/driver.go
+++ b/driver.go
@@ -102,7 +102,18 @@ func (d *Driver) Create() (err error) {
 			log.Warn("set label of VM failed:", err)
 		}
 	}
-	if d.IbaServiceCode == "" {
+	if d.baseImage != "" {
+		restoreParams := strings.Split(d.baseImage, ",")
+		if err = d.restore(restoreParams[0], restoreParams[1]); err != nil {
+ 			return
+ 		}
+ 		if err = d.waitstatus("systemstorage", d.IbaServiceCode, "InService", "NotAttached"); err != nil {
+ 			return
+ 		}
+		if err = d.setSysStlabel(d.MachineName); err != nil {
+			log.Warn("set label of SystemStorage failed:", err)
+		}
+	} else if d.IbaServiceCode == "" {
 		if err = d.createdisk(); err != nil {
 			return
 		}
@@ -112,15 +123,6 @@ func (d *Driver) Create() (err error) {
 		if err = d.setSysStlabel(d.MachineName); err != nil {
 			log.Warn("set label of SystemStorage failed:", err)
 		}
-	}
-	if d.baseImage != "" {
-		restoreParams := strings.Split(d.baseImage, ",")
-		if err = d.restore(restoreParams[0], restoreParams[1]); err != nil {
- 			return
- 		}
- 		if err = d.waitstatus("systemstorage", d.IbaServiceCode, "InService", "NotAttached"); err != nil {
- 			return
- 		}
 	}
 	if err = ssh.GenerateSSHKey(d.GetSSHKeyPath()); err != nil {
 		log.Error(err)

--- a/driver.go
+++ b/driver.go
@@ -46,6 +46,7 @@ type Driver struct {
 	addStorageType string
 	baseImage      string
 	extraPorts     string
+	customARP      bool
 }
 
 type openport struct {
@@ -240,6 +241,12 @@ func (d *Driver) osInit(cmd oscmd.Oscmd) (res []string, err error) {
 		res = append(res, cmd.DNS([]string{netinfo[1]})...)
 		log.Debug("cmd3:", res)
 	}
+
+	if d.customARP {
+		log.Infof("set arp parameters")
+		res = append(res, cmd.ARP()...)
+	}
+
 	return
 }
 
@@ -364,6 +371,10 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Name: "p2pub-extra-ports",
 			Usage: "open extra ports",
 		},
+		mcnflag.BoolFlag{
+			Name: "p2pub-reply-any-arp",
+			Usage: "advanced: set kernel parameters to reply any arp requests",
+		},
 	}
 }
 
@@ -384,6 +395,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.addStorageType = flags.String("p2pub-data-storage")
 	d.baseImage = flags.String("p2pub-custom-image")
 	d.extraPorts = flags.String("p2pub-extra-ports")
+	d.customARP = flags.Bool("p2pub-reply-any-arp")
 	d.SetSwarmConfigFromFlags(flags)
 	if d.AccessKey == "" || d.SecretKey == "" || d.GisServiceCode == "" {
 		return fmt.Errorf("p2pub driver requires --p2pub-{access,secret}-key, --p2pub-gis option: %+v", d)

--- a/oscmd/os.go
+++ b/oscmd/os.go
@@ -6,6 +6,7 @@ type Oscmd interface {
 	OpenFW(port int, proto string) []string
 	DefGW(addr string) []string
 	DNS(addrs []string) []string
+	ARP() []string
 }
 
 type Linux struct{}
@@ -20,4 +21,15 @@ func (l Linux) DNS(addrs []string) []string {
 		res = append(res, fmt.Sprintf("echo nameserver %s | tee -a /etc/resolv.conf", v))
 	}
 	return res
+}
+
+func (l Linux) ARP() []string {
+	return []string{
+		"echo 'net.ipv4.conf.default.arp_ignore = 0' >> /etc/sysctl.conf",
+		"echo 'net.ipv4.conf.default.arp_announce = 0' >> /etc/sysctl.conf",
+		"echo 'net.ipv4.conf.default.arp_notify = 0' >> /etc/sysctl.conf",
+		"echo 'net.ipv4.conf.default.arp_filter = 0' >> /etc/sysctl.conf",
+		"echo 'net.ipv4.conf.default.arp_accept = 0' >> /etc/sysctl.conf",
+		"sysctl -p",
+	}
 }

--- a/oscmd/rhel.go
+++ b/oscmd/rhel.go
@@ -20,6 +20,17 @@ func (l RedHat) DefGW(addr string) []string {
 	}
 }
 
+func (l RedHat) ARP() []string {
+	return []string{
+		"echo 'net.ipv4.conf.default.arp_ignore = 0' >> /etc/sysctl.conf",
+		"echo 'net.ipv4.conf.default.arp_announce = 0' >> /etc/sysctl.conf",
+		"echo 'net.ipv4.conf.default.arp_notify = 0' >> /etc/sysctl.conf",
+		"echo 'net.ipv4.conf.default.arp_filter = 0' >> /etc/sysctl.conf",
+		"echo 'net.ipv4.conf.default.arp_accept = 0' >> /etc/sysctl.conf",
+		"sysctl -p",
+	}
+}
+
 type CentOS struct {
 	RedHat
 }

--- a/oscmd/ubuntu.go
+++ b/oscmd/ubuntu.go
@@ -23,6 +23,17 @@ func (l Ubuntu) DNS(addrs []string) []string {
 	return res
 }
 
+func (l Ubuntu) ARP() []string {
+	return []string{
+		"echo 'net.ipv4.conf.default.arp_ignore = 0' >> /etc/sysctl.conf",
+		"echo 'net.ipv4.conf.default.arp_announce = 0' >> /etc/sysctl.conf",
+		"echo 'net.ipv4.conf.default.arp_notify = 0' >> /etc/sysctl.conf",
+		"echo 'net.ipv4.conf.default.arp_filter = 0' >> /etc/sysctl.conf",
+		"echo 'net.ipv4.conf.default.arp_accept = 0' >> /etc/sysctl.conf",
+		"sysctl -p",
+	}
+}
+
 type Debian struct {
 	Ubuntu
 }


### PR DESCRIPTION
Rancher に組み込む際に必要になる設定をオプション指定によって行えるようにしました。追加したオプションは以下の三つです。

- `--p2pub-extra-ports`: 追加で開放するポートを指定する
- `--p2pub-reply-any-arp`: すべての ARP リクエストに応答する (arp_ignore等を 0 にする) よう設定する
- `--p2pub-custom-image`: ブートデバイスをカスタムOSイメージからレストアして作成する

その他、既存の machine driver ではシステムストレージを新規作成した場合にのみ SSH 公開鍵を登録していましたが、どのようなケースでも必ず SSH 鍵を登録し直すよう変更を入れてあります。